### PR TITLE
Testing regression to the original Trusty 9.10

### DIFF
--- a/tests/scripts/ghostscript-install.sh
+++ b/tests/scripts/ghostscript-install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-apt-get install ghostscript
+apt-get install ghostscript=9.10~dfsg-0ubuntu10


### PR DESCRIPTION
```9.10~dfsg-0ubuntu10 is the original (2014)```
```9.10~dfsg-0ubuntu10.10 is the security patch (Aug 2017)```
Maybe there is an issue there. Let's see! But we need to update our code for sure anyway

